### PR TITLE
Fix build with Qt 5.15.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ find_package(Qt5 "${QT_MIN_VERSION}"
         Gui
         WaylandClient
 )
+if(${Qt5_VERSION} VERSION_GREATER "5.15.1")
+    find_package(Qt5 "${QT_MIN_VERSION}"
+        CONFIG REQUIRED
+        COMPONENTS XkbCommonSupport)
+endif()
 
 ## Add subdirectories:
 add_subdirectory(src/plugins/decorations/material)

--- a/src/plugins/decorations/material/CMakeLists.txt
+++ b/src/plugins/decorations/material/CMakeLists.txt
@@ -12,3 +12,8 @@ liri_add_plugin(materialdecoration
         Qt5::WaylandClientPrivate
         Wayland::Client
 )
+
+if(${Qt5_VERSION} VERSION_GREATER "5.15.1")
+    liri_extend_target("materialdecoration"
+        LIBRARIES Qt5::XkbCommonSupport)
+endif()


### PR DESCRIPTION
Make sure we link to Qt5::XkbCommonSupport which is used by
QtWaylandClient internally.

Closes: #11